### PR TITLE
Version 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: zs-yaml CI/CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Set version
+        id: set_version
+        run: |
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          elif [[ $GITHUB_REF == refs/heads/main ]]; then
+            VERSION=$(python setup.py --version)
+          else
+            VERSION=$(python setup.py --version).dev0
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          sed -i "s/__version__ = .*/__version__ = '${VERSION}'/" zs_yaml/_version.py
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.KE_PYPI_TOKEN }}
+        run: |
+          twine check dist/*
+          twine upload dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: zs-yaml CI/CD
-
 on:
   push:
     branches:
@@ -11,7 +10,7 @@ on:
       - main
 
 jobs:
-  build-and-deploy:
+  test-build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,8 +22,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+      - name: Install zs-yaml in dev mode
+        run: |
+          pip install -e .
+      - name: Generate schema API for team example
+        run: |
+          cd examples/team
+          zserio team.zs -withTypeInfoCode -python zs_gen_api
+          echo "PYTHONPATH=$PYTHONPATH:$PWD/zs_gen_api" >> $GITHUB_ENV
+      - name: Test team example transformation
+        run: |
+          cd examples/team
+          zs-yaml team1.yaml team1_test_out.bin
+          if [ $? -eq 0 ]; then
+            echo "Transformation successful"
+          else
+            echo "Transformation failed"
+            exit 1
+          fi
       - name: Set version
-        id: set_version
         run: |
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -34,15 +50,18 @@ jobs:
             VERSION=$(python setup.py --version).dev0
           fi
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "Extracted version: ${VERSION}"
           sed -i "s/__version__ = .*/__version__ = '${VERSION}'/" zs_yaml/_version.py
       - name: Build package
         run: |
           python setup.py sdist bdist_wheel
+      - name: Check distribution
+        run: |
+          twine check dist/*
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.KE_PYPI_TOKEN }}
         run: |
-          twine check dist/*
           twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -39,6 +39,44 @@ _meta:
   schema_type: <type_name>
 ```
 
+### Initialization Arguments
+
+Some Zserio types require additional arguments during initialization, either when deserializing from binary or when creating objects from JSON. To support these types, you can specify initialization arguments in the `_meta` section of your YAML file:
+
+```yaml
+_meta:
+  schema_module: <module_name>
+  schema_type: <type_name>
+  initialization_args:
+    - <arg1>
+    - <arg2>
+    # ... more arguments as needed
+```
+
+**Hint:** At the moment only plain values are supported, although zserio supports also compound values as args.
+Support for these may be added in the future.
+
+These arguments will be passed to the appropriate Zserio functions:
+- `zserio.deserialize_from_file()` when converting from binary to YAML
+- `zserio.from_json_file()` when converting from YAML to binary
+
+For example:
+
+```yaml
+_meta:
+  schema_module: my_schema
+  schema_type: MyType
+  initialization_args:
+    - 0xAB
+    - 42
+
+# ... rest of your YAML data
+```
+
+In this example, `0xAB` and `42` will be passed as additional arguments to the initialization functions.
+
+This feature ensures that types requiring additional initialization parameters can be properly handled in both directions of conversion (YAML to binary and binary to YAML).
+
 ## Example
 
 ### Zserio Schema Module Creation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="doc/zs-yaml.png" alt="" height="100">
 
-**zs-yaml** adds YAML as a text format to be used with [zserio](https://github.com/ndsev/zserio) in order to improve the user experience when manually creating or analyzing test data for specific zserio schemas.
+**zs-yaml** adds YAML as a text format to be used with zserio in order to improve the user experience when manually creating or analyzing test data for zserio.
 
 - **YAML Format**: Uses YAML's human-readable format instead of JSON as the primary format for editing, making data handling and transformation more intuitive and less cluttered.
 - **Metadata Inclusion**: Automatically includes metadata in the YAML, eliminating the need for users to manually identify the correct type when importing JSON data, ensuring seamless (de-)serialization.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ After you have installed `zs-yaml`, call `zs-yaml` to convert your YAML file to 
 zs-yaml person.yaml person.bin
 ```
 
+## Built-in Transformations
+
+zs-yaml comes with several built-in transformation functions that can be used in your YAML files. Here's a brief overview of the available functions:
+
+- `insert_yaml_as_extern`: Includes external YAML content by transforming it to JSON and using zserio.
+- `insert_yaml`: Inserts YAML content directly from an external file.
+- `repeat_node`: Repeats a specific node a specified number of times.
+- `extract_extern_as_yaml`: Extracts binary data and saves it as an external YAML file.
+
+For more detailed information about these functions and their usage, please refer to the [built_in_transformations.py](https://github.com/ndsev/zs_yaml/blob/main/zs_yaml/built_in_transformations.py) source file.
+
+Note: We plan to implement automatic source documentation generation in a future release, which will provide more comprehensive information about these functions and their parameters.
+
 ## Project Structure
 
 - `setup.py`: Script for setting up the project and installing dependencies.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@
 - **Metadata Inclusion**: Automatically includes metadata in the YAML, eliminating the need for users to manually identify the correct type when importing JSON data, ensuring seamless (de-)serialization.
 - **Custom Transformations**: Allows for hooking in custom transformations so that users can work with familiar formats (e.g., dates or coordinate representations) instead of thinking in unfamiliar formats.
 
+## Design Principles
+
+1. **Transparency Over Magic**:
+   - Prioritize clear and understandable processes. For example, users can fully render the YAML to see the actual data conforming to the underlying zserio schema.
+   - This approach avoids black-box conversions, simplifying debugging and ensuring user confidence in the data.
+
+2. **Accessibility and Simplicity**:
+   - Make the tool easy to use and understand, even for beginners.
+   - Features are designed with simplicity in mind. For instance, we use string-only templates as one way to keep things straightforward.
+
+3. **Performance for Trusted Sources**:
+   - Optimize for performance, assuming trusted YAML sources.
+   - Faster processing is crucial for rapid iterations and maintaining workflow.
+
+4. **Flexibility Within Simplicity**:
+   - While maintaining a simple core, provide powerful features like YAML imports, built-in and custom transformations, and basic templating.
+   - This balance allows for adaptability to various use cases without compromising ease of use.
+
 ## Installation
 
 Install `zs-yaml` using pip:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,40 @@
 
 <img src="doc/zs-yaml.png" alt="" height="100">
 
-**zs-yaml** adds YAML as a text format to be used with zserio in order to improve the user experience when manually creating or analyzing test data for zserio.
+**zs-yaml** adds YAML as a text format to be used with [zserio](https://github.com/ndsev/zserio) in order to improve the user experience when manually creating or analyzing test data for specific zserio schemas.
 
 - **YAML Format**: Uses YAML's human-readable format instead of JSON as the primary format for editing, making data handling and transformation more intuitive and less cluttered.
 - **Metadata Inclusion**: Automatically includes metadata in the YAML, eliminating the need for users to manually identify the correct type when importing JSON data, ensuring seamless (de-)serialization.
 - **Custom Transformations**: Allows for hooking in custom transformations so that users can work with familiar formats (e.g., dates or coordinate representations) instead of thinking in unfamiliar formats.
+
+## Installation
+
+Install `zs-yaml` using pip:
+
+```bash
+python -m pip install --upgrade zs-yaml
+```
+
+## Usage
+
+The main entry point for the application is `zs-yaml`. It accepts arguments for specifying the input and output file paths. You can run the application as follows:
+
+```bash
+zs-yaml input.yaml output.bin
+zs-yaml input.bin output.yaml
+```
+
+### Notes
+
+- You have to use the exact same order of fields in the YAML as defined by the zserio schema, because zserio expects this.
+- When converting from binary to YAML, the target YAML file must already exist and contain the necessary metadata.
+- The minimal metadata content in the target YAML file should be:
+
+```yaml
+_meta:
+  schema_module: <module_name>
+  schema_type: <type_name>
+```
 
 ## Example
 
@@ -60,8 +89,9 @@ Using **zs-yaml**, you can define the same data in a more human-readable YAML fo
 ```yaml
 # 1) Metadata is used to specify the type needed for
 #    (de-)serialization and custom transform functions
-# 2) User are free to use their preferred date format
+# 2) Users are free to use their preferred date format
 #    for the birth data as the a normalization function
+#    (defined in the referenced `transformations.py`)
 #    get invoked.
 # 3) Yaml allows avoiding clutter and adding comments
 #    like this one :)
@@ -113,40 +143,6 @@ After you have installed `zs-yaml`, call `zs-yaml` to convert your YAML file to 
 # Create the binary representation from the YAML file
 zs-yaml person.yaml person.bin
 ```
-
-## Installation
-
-Currently, the Python package is only available at test.pypi. Once the official release is available,
-you can install the package without specifying an index URL.
-
-```bash
-python -m pip install --upgrade zs-yaml
-```
-
-## Usage
-
-The main entry point for the application is `main.py`. It accepts arguments for specifying the input and output file paths. You can run the application as follows:
-
-```bash
-zs-yaml input.yaml output.bin
-zs-yaml input.bin output.yaml
-```
-
-### Notes
-
-- You have to use the exact same order of field in the yaml as defined by the zserio schema, because zserio expects this
-- When converting from binary to YAML, the target YAML file must already exist and contain the necessary metadata.
-- The minimal metadata content in the target YAML file should be:
-
-```yaml
-_meta:
-  schema_module: <module_name>
-  schema_type: <type_name>
-```
-
-### Future Considerations
-
-In the future, we may consider using YAML tags for a more integrated approach to handling transformations directly within the YAML files, simplifying syntax and enhancing readability.
 
 ## Project Structure
 

--- a/examples/team/addresses.yaml
+++ b/examples/team/addresses.yaml
@@ -1,0 +1,14 @@
+
+- city_only: "New York"
+  detailed:
+    street: "123 Main St"
+    city: "New York"
+    country: "USA"
+    zipCode: 10001
+
+- city_only: "San Francisco"
+  detailed:
+    street: "456 Elm St"
+    city: "San Francisco"
+    country: "USA"
+    zipCode: 94102

--- a/examples/team/custom_transformations.py
+++ b/examples/team/custom_transformations.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+
+
+def calculate_age(transformer, birthdate):
+    born = datetime.strptime(birthdate, "%Y-%m-%d")
+    today = datetime.today()
+    return today.year - born.year - ((today.month, today.day) < (born.month, born.day))

--- a/examples/team/hobbies.yaml
+++ b/examples/team/hobbies.yaml
@@ -1,0 +1,9 @@
+common:
+  - "Reading"
+  - "Traveling"
+  - "Photography"
+
+jane_smith:
+  - "Hiking"
+  - "Cooking"
+  - "Painting"

--- a/examples/team/skills.yaml
+++ b/examples/team/skills.yaml
@@ -1,0 +1,6 @@
+- name: "Python"
+  level: 9
+- name: "JavaScript"
+  level: 8
+- name: "Database Management"
+  level: 7

--- a/examples/team/team.zs
+++ b/examples/team/team.zs
@@ -1,0 +1,34 @@
+package team;
+
+struct Address {
+    string street;
+    string city;
+    string country;
+    uint32 zipCode;
+};
+
+struct Experience {
+    string company;
+    string position;
+    uint16 yearsWorked;
+};
+
+struct Skill {
+    string name;
+    uint8 level;
+};
+
+struct Person {
+    string name;
+    uint32 age;
+    Address address;
+    Experience workExperience[];
+    Skill skills[];
+    string hobbies[];
+    string bio;
+};
+
+struct Team {
+    string name;
+    Person members[];
+};

--- a/examples/team/team1.yaml
+++ b/examples/team/team1.yaml
@@ -1,0 +1,55 @@
+_meta:
+  schema_module: team.api
+  schema_type: Team
+  transformation_module: "./custom_transformations.py"
+
+name: "Dream Team"
+
+members:
+  - name: "John Doe"
+    age:
+      _f: calculate_age
+      _a: "1990-05-15"
+    address:
+      _f: insert_yaml
+      _a:
+        file: "addresses.yaml"
+        node_path: "[0].detailed"
+    workExperience:
+      _f: insert_yaml
+      _a:
+        file: "work_experience.yaml"
+        node_path: "john_doe"
+    skills:
+      _f: insert_yaml
+      _a: "skills.yaml"
+    hobbies:
+      _f: insert_yaml
+      _a:
+        file: "hobbies.yaml"
+        node_path: "common"
+    bio: "Just some bio."
+
+  - name: "Jane Smith"
+    age:
+      _f: calculate_age
+      _a: "1988-09-23"
+    address:
+      _f: insert_yaml
+      _a:
+        file: "addresses.yaml"
+        node_path: "[1].detailed"
+    workExperience:
+      _f: insert_yaml
+      _a:
+        file: "work_experience.yaml"
+        node_path: "jane_smith"
+    skills:
+      _f: insert_yaml
+      _a: "skills.yaml"
+    hobbies:
+      _f: insert_yaml
+      _a:
+        file: "hobbies.yaml"
+        node_path: "jane_smith"
+    bio: "Another bio."

--- a/examples/team/team1.yaml
+++ b/examples/team/team1.yaml
@@ -21,8 +21,14 @@ members:
         file: "work_experience.yaml"
         node_path: "john_doe"
     skills:
-      _f: insert_yaml
-      _a: "skills.yaml"
+      _f: repeat_node
+      _a:
+        count: 4
+        node:
+          _f: insert_yaml
+          _a:
+            file: "skills.yaml"
+            node_path: "[0]"
     hobbies:
       _f: insert_yaml
       _a:

--- a/examples/team/work_experience.yaml
+++ b/examples/team/work_experience.yaml
@@ -1,0 +1,15 @@
+john_doe:
+  - company: "Tech Corp"
+    position: "Senior Developer"
+    yearsWorked: 5
+  - company: "Startup Inc"
+    position: "Junior Developer"
+    yearsWorked: 2
+
+jane_smith:
+  - company: "Big Enterprise"
+    position: "Project Manager"
+    yearsWorked: 6
+  - company: "Small Business"
+    position: "Business Analyst"
+    yearsWorked: 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML~=6.0
-zserio~=2.12
+zserio~=2.14.1

--- a/zs_yaml/_version.py
+++ b/zs_yaml/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.1a2'
 __commit_id__ = '7217bfe'
+__version__ = '0.4.0'

--- a/zs_yaml/_version.py
+++ b/zs_yaml/_version.py
@@ -1,2 +1,2 @@
-__commit_id__ = 'ebfe593'
-__version__ = '0.3.0'
+__version__ = '0.3.1a2'
+__commit_id__ = '7217bfe'

--- a/zs_yaml/built_in_transformations.py
+++ b/zs_yaml/built_in_transformations.py
@@ -3,6 +3,11 @@ import importlib
 import zserio
 import yaml
 import copy
+from functools import reduce
+import operator
+
+# Cache to store loaded YAML/JSON files
+_file_cache = {}
 
 def insert_yaml_as_extern(transformer, file, template_args=None):
     """
@@ -43,22 +48,84 @@ def insert_yaml_as_extern(transformer, file, template_args=None):
 
     return data
 
-def insert_yaml(transformer, file, template_args=None):
+def insert_yaml(transformer, file, node_path='', template_args=None, cache_file=True):
     """
-    Insert YAML content directly without converting to binary.
+    Insert content from an external YAML or JSON file, optionally selecting a specific node.
+    Uses a cache to avoid reloading the same file multiple times if caching is enabled.
 
     Args:
         transformer (YamlTransformer): The transformer instance.
-        file (str): Path to the external YAML file.
+        file (str): Path to the external YAML or JSON file.
+        node_path (str, optional): Dot-separated path to the node to be inserted.
+                                   Defaults to '', which selects the entire file content.
         template_args (dict, optional): A dictionary of template arguments for placeholder replacement.
+        cache_file (bool, optional): Whether to cache the file content. Defaults to True.
 
     Returns:
-        dict: The processed YAML data.
+        The selected content from the external file.
     """
-    abs_path = transformer.resolve_path(file)
-    external_transformer = transformer.__class__(abs_path, template_args, initial_transformations=transformer.transformations)
-    processed_data = external_transformer.transform()
-    return processed_data
+    def get_from_dict(data_dict, map_list):
+        return reduce(operator.getitem, map_list, data_dict)
+
+    def load_file(file_path):
+        if cache_file and file_path in _file_cache:
+            return _file_cache[file_path]
+
+        abs_path = transformer.resolve_path(file_path)
+        if file_path.lower().endswith(('.yaml', '.yml')):
+            with open(abs_path, 'r') as f:
+                content = f.read()
+                if template_args:
+                    content = Template(content).safe_substitute(template_args)
+                data = yaml.safe_load(content)
+        elif file_path.lower().endswith('.json'):
+            with open(abs_path, 'r') as f:
+                data = json.load(f)
+        else:
+            raise ValueError(f"Unsupported file format for {file_path}. Only YAML and JSON are supported.")
+
+        if cache_file:
+            _file_cache[file_path] = data
+
+        # Deep copy is not good from performance point of
+        # view but it still avoids loading the file again and
+        # again and the nodes don't appear as alias but are
+        # are really copies when used multiple times
+        return copy.deepcopy(data)
+
+    # Load the external data
+    external_data = load_file(file)
+
+    # If no specific node is requested, return the entire content
+    if not node_path:
+        return external_data
+
+    # Parse the path and extract the node
+    parsed_path = []
+    current_key = ""
+    for char in node_path:
+        if char == '.':
+            if current_key:
+                parsed_path.append(current_key)
+                current_key = ""
+        elif char == '[':
+            if current_key:
+                parsed_path.append(current_key)
+                current_key = ""
+        elif char == ']':
+            if current_key:
+                parsed_path.append(int(current_key))
+                current_key = ""
+        else:
+            current_key += char
+    if current_key:
+        parsed_path.append(current_key)
+    print(f"parsed_path: {parsed_path}")
+
+    try:
+        return get_from_dict(external_data, parsed_path)
+    except (KeyError, IndexError, TypeError):
+        raise ValueError(f"Invalid path: {node_path} in file {file}")
 
 def repeat_node(transformer, node, count):
     """

--- a/zs_yaml/convert.py
+++ b/zs_yaml/convert.py
@@ -56,7 +56,7 @@ def yaml_to_yaml(yaml_input_path, yaml_output_path=None):
         output_data = {'_meta': meta}
         output_data.update(transformer.data)
         with open(yaml_output_path, 'w') as yaml_file:
-            yaml.dump(output_data, yaml_file, default_flow_style=False, sort_keys=False)
+            yaml.dump(output_data, yaml_file, Dumper=yaml.CDumper, default_flow_style=False, sort_keys=False)
 
     return transformer.data, meta
 

--- a/zs_yaml/convert.py
+++ b/zs_yaml/convert.py
@@ -49,17 +49,16 @@ def yaml_to_yaml(yaml_input_path, yaml_output_path=None):
         yaml_input_path (str): Path to the input YAML file.
         yaml_output_path (str): Path to the output YAML file.
     """
-    transformer = YamlTransformer(yaml_input_path)
-    transformed_data = transformer.transform()
+    transformer = YamlTransformer.get_or_create(yaml_input_path)
     meta = transformer.get_meta()
 
     if yaml_output_path:
         output_data = {'_meta': meta}
-        output_data.update(transformed_data)
+        output_data.update(transformer.data)
         with open(yaml_output_path, 'w') as yaml_file:
             yaml.dump(output_data, yaml_file, default_flow_style=False, sort_keys=False)
 
-    return transformed_data, meta
+    return transformer.data, meta
 
 
 def yaml_to_json(yaml_input_path, json_output_path):

--- a/zs_yaml/yaml_transformer.py
+++ b/zs_yaml/yaml_transformer.py
@@ -89,7 +89,7 @@ class YamlTransformer:
         elif isinstance(data, dict):
             if '_f' in data and '_a' in data:
                 func = self._get_function(data['_f'])
-                args = data['_a']
+                args = self._process(data['_a'])  # Process the arguments recursively
                 if func and callable(func):
                     if isinstance(args, dict):
                         return func(self, **args)

--- a/zs_yaml/yaml_transformer.py
+++ b/zs_yaml/yaml_transformer.py
@@ -28,7 +28,7 @@ class YamlTransformer:
         if template_args:
             content = Template(content).safe_substitute(template_args)
 
-        self.original_data = yaml.safe_load(content)
+        self.original_data = yaml.load(content, Loader=yaml.CLoader)
         if ('_meta' in self.original_data):
             self.metadata = self.original_data.pop('_meta', {})
             transformation_module = self.metadata.get('transformation_module')

--- a/zs_yaml/yaml_transformer.py
+++ b/zs_yaml/yaml_transformer.py
@@ -108,10 +108,8 @@ class YamlTransformer:
 
         cache = YamlTransformer._transformed_yaml_cache
         if cache_key in cache:
-            print(f"YamlTransformer::Cache: Hit for {cache_key}")
             return cache[cache_key]
 
-        print(f"YamlTransformer::Cache: Miss for {cache_key}")
         transformed_yaml = cls(abs_path, template_args, initial_transformations)
         cache[cache_key] = transformed_yaml
         return transformed_yaml


### PR DESCRIPTION
Changes:
- Support nested invocation of functions (e.g. convert some data and then repeat it)
- Support referencing a single node when using `insert_yaml` then only this node gets inserted
- Use C-based implementation of YAML loader and dumper which is significantly faster
- Add in-memory cache for loaded YAMLs to improve performance when referencing the same file multiple times. This is especially useful when using the lib variant of zs-yaml in a Python app.
- Add an example which demonstrates the different aspects of `zs-yaml` and can be used without copy&paste from the README
- Reflect `Design Principles` in the README