### PR TITLE
Release 0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,20 @@ jobs:
             echo "Conversion tests failed"
             exit 1
           fi
+      - name: Generate schema API for extern_compression example
+        run: |
+          cd examples/extern_compression
+          zserio extern_compression.zs -withTypeInfoCode -python zs_gen_api
+      - name: Test extern compression
+        run: |
+          cd examples/extern_compression
+          PYTHONPATH="$PWD/zs_gen_api" python test_compression.py
+          if [ $? -eq 0 ]; then
+            echo "Compression tests successful"
+          else
+            echo "Compression tests failed"
+            exit 1
+          fi
       - name: Build package
         run: |
           python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-23
+
+### Added
+- `insert_yaml_as_extern` supports compressing the produced extern bytes via a new `compression_type` argument (zlib, zstd, lz4, brotli). Fixes #19
+- `extern_compression` example schema plus `test_compression.py` covering unit and end-to-end round-trips for all compression types
+
+### Changed
+- `extract_extern_as_yaml` and `insert_yaml_as_extern` now share a single `_decompress` / `_compress` helper pair so new algorithms plug in one place
+- `extract_extern_as_yaml` default for `compression_type` aligned to `None` (was `0`); behavior is unchanged for all callers
+
 ## [0.8.3] - 2025-12-07
 
 ### Added
@@ -38,7 +48,7 @@ _Superseded by v0.8.3 - missing `bin_to_dict` export_
 
 ### Added
 - `py_eval` transformation function for generating node values via Python snippets
-- `extract_extern_as_yaml` supports compressed externals (gzip, zstd, lz4, brotli)
+- `extract_extern_as_yaml` supports compressed externals (zlib, zstd, lz4, brotli)
 - `extract_extern_as_yaml` supports generating YAMLs without null-value fields
 
 ## [0.6.1] - 2024-12-04

--- a/README.md
+++ b/README.md
@@ -218,10 +218,17 @@ zs-yaml person.yaml person.bin
 
 zs-yaml comes with several built-in transformation functions that can be used in your YAML files. Here's a brief overview of the available functions:
 
-- `insert_yaml_as_extern`: Includes external YAML content by transforming it to JSON and using zserio.
+- `insert_yaml_as_extern`: Includes external YAML content by transforming it to JSON and using zserio. Optionally compresses the produced bytes via `compression_type` (`zlib`, `zstd`, `lz4`, `brotli`; omit or set to `no_compression` for raw). Example:
+  ```yaml
+  data:
+    _f: insert_yaml_as_extern
+    _a:
+      file: payload.yaml
+      compression_type: zstd   # enum name, integer (0-4) or CompressionType member
+  ```
 - `insert_yaml`: Inserts YAML content directly from an external file.
 - `repeat_node`: Repeats a specific node a specified number of times.
-- `extract_extern_as_yaml`: Extracts binary data and saves it as an external YAML file.
+- `extract_extern_as_yaml`: Extracts binary data and saves it as an external YAML file. Accepts the same `compression_type` values as `insert_yaml_as_extern` and decompresses the buffer before deserialization.
 - `py_eval`: Allows to write small snippets like `myArray: {_f: py_eval, _a: "list(range(1, 100))"}` to generate the value for a yaml node.
 
 For more detailed information about these functions and their usage, please refer to the [built_in_transformations.py](https://github.com/ndsev/zs-yaml/blob/main/zs_yaml/built_in_transformations.py) source file.

--- a/examples/extern_compression/extern_compression.zs
+++ b/examples/extern_compression/extern_compression.zs
@@ -1,0 +1,23 @@
+package extern_compression;
+
+enum uint8 CompressionType
+{
+    NO_COMPRESSION = 0,
+    ZLIB = 1,
+    ZSTD = 2,
+    LZ4 = 3,
+    BROTLI = 4
+};
+
+struct Payload
+{
+    string name;
+    uint32 value;
+    string tags[];
+};
+
+struct CompressedBlob
+{
+    CompressionType compressionType;
+    extern data;
+};

--- a/examples/extern_compression/payload.yaml
+++ b/examples/extern_compression/payload.yaml
@@ -1,0 +1,10 @@
+_meta:
+  schema_module: extern_compression.api
+  schema_type: Payload
+
+name: "test payload"
+value: 42
+tags:
+  - "alpha"
+  - "beta"
+  - "gamma"

--- a/examples/extern_compression/test_compression.py
+++ b/examples/extern_compression/test_compression.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for compression support in insert_yaml_as_extern / extract_extern_as_yaml."""
+
+import os
+import sys
+import tempfile
+import yaml
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(SCRIPT_DIR, '..', '..')))
+sys.path.insert(0, os.path.join(SCRIPT_DIR, 'zs_gen_api'))
+
+from zs_yaml.built_in_transformations import (
+    CompressionType,
+    _compress,
+    extract_extern_as_yaml,
+)
+from zs_yaml.convert import yaml_to_bin, bin_to_dict
+from zs_yaml.yaml_transformer import YamlTransformer
+
+COMPRESSION_CASES = [
+    ('NONE',   CompressionType.NO_COMPRESSION, 0),
+    ('ZLIB',   CompressionType.ZLIB,           1),
+    ('ZSTD',   CompressionType.ZSTD,           2),
+    ('LZ4',    CompressionType.LZ4,            3),
+    ('BROTLI', CompressionType.BROTLI,         4),
+]
+
+
+def test_compress_unit():
+    """_compress round-trips via each algorithm's own decompressor."""
+    print("Testing _compress unit round-trips...")
+    import zlib, zstandard, lz4.frame, brotli
+    data = b'hello world, repeatable payload for compression testing. ' * 20
+
+    decompressors = {
+        CompressionType.ZLIB:   zlib.decompress,
+        CompressionType.ZSTD:   lambda b: zstandard.ZstdDecompressor().decompress(b),
+        CompressionType.LZ4:    lz4.frame.decompress,
+        CompressionType.BROTLI: brotli.decompress,
+    }
+
+    for name, ct, _ in COMPRESSION_CASES:
+        compressed = _compress(data, ct)
+        if ct == CompressionType.NO_COMPRESSION:
+            assert compressed == data, "NO_COMPRESSION should be identity"
+            print(f"   ✓ _compress[{name}] identity")
+            continue
+        assert decompressors[ct](compressed) == data, f"{name} round-trip failed"
+        print(f"   ✓ _compress[{name}] round-trip")
+
+
+def test_compression_type_arg_resolution():
+    """compression_type accepts enum / string / int and rejects junk."""
+    print("\nTesting compression_type argument resolution...")
+    assert CompressionType.from_string("zstd") == CompressionType.ZSTD
+    assert CompressionType.from_string("ZLIB") == CompressionType.ZLIB
+    assert CompressionType(3) == CompressionType.LZ4
+    try:
+        CompressionType.from_string("nope")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unknown compression name should raise")
+    print("   ✓ enum/string/int resolution ok")
+
+
+def _wrapper_yaml(ct_int, abs_payload_path):
+    return (
+        "_meta:\n"
+        "  schema_module: extern_compression.api\n"
+        "  schema_type: CompressedBlob\n"
+        "\n"
+        f"compressionType: {ct_int}\n"
+        "data:\n"
+        "  _f: insert_yaml_as_extern\n"
+        "  _a:\n"
+        f"    file: \"{abs_payload_path}\"\n"
+        f"    compression_type: {ct_int}\n"
+    )
+
+
+def _normalize_ct(value):
+    if isinstance(value, CompressionType):
+        return value.value
+    if isinstance(value, str):
+        return CompressionType.from_string(value).value
+    return int(value)
+
+
+def test_roundtrip_via_extract_extern():
+    """wrapper.yaml -> bin -> dict -> extract_extern_as_yaml -> compare."""
+    print("\nTesting end-to-end compression roundtrip...")
+
+    payload_abs = os.path.join(SCRIPT_DIR, 'payload.yaml')
+    with open(payload_abs) as f:
+        expected = yaml.safe_load(f)
+    expected_fields = {k: v for k, v in expected.items() if k != '_meta'}
+
+    for name, ct, ct_int in COMPRESSION_CASES:
+        with tempfile.TemporaryDirectory() as td:
+            wrapper_path = os.path.join(td, f'wrapper_{name}.yaml')
+            bin_path = os.path.join(td, f'blob_{name}.bin')
+            with open(wrapper_path, 'w') as f:
+                f.write(_wrapper_yaml(ct_int, payload_abs))
+
+            yaml_to_bin(wrapper_path, bin_path)
+
+            decoded, _ = bin_to_dict(bin_path, 'extern_compression.api', 'CompressedBlob')
+            assert _normalize_ct(decoded['compressionType']) == ct_int, (
+                f"[{name}] compressionType mismatch: got {decoded['compressionType']!r}, want {ct_int}"
+            )
+
+            host_yaml_path = os.path.join(td, f'host_{name}.yaml')
+            with open(host_yaml_path, 'w') as f:
+                f.write("_meta:\n  schema_module: extern_compression.api\n  schema_type: Payload\n")
+            host_transformer = YamlTransformer(host_yaml_path)
+
+            extracted_name = f'extracted_{name}.yaml'
+            extract_extern_as_yaml(
+                host_transformer,
+                buffer=decoded['data']['buffer'],
+                bitSize=decoded['data']['bitSize'],
+                schema_module='extern_compression.api',
+                schema_type='Payload',
+                file_name=extracted_name,
+                compression_type=ct_int,
+            )
+
+            with open(os.path.join(td, extracted_name)) as f:
+                extracted = yaml.safe_load(f)
+            extracted_fields = {k: v for k, v in extracted.items() if k != '_meta'}
+
+            assert extracted_fields == expected_fields, (
+                f"[{name}] extracted payload differs from input:\n"
+                f"  got:      {extracted_fields!r}\n"
+                f"  expected: {expected_fields!r}"
+            )
+            print(f"   ✓ roundtrip[{name}] ok")
+
+
+if __name__ == "__main__":
+    try:
+        test_compress_unit()
+        test_compression_type_arg_resolution()
+        test_roundtrip_via_extract_extern()
+        print("\n✅ All compression tests passed!")
+        sys.exit(0)
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/zs_yaml/built_in_transformations.py
+++ b/zs_yaml/built_in_transformations.py
@@ -30,7 +30,21 @@ class CompressionType(Enum):
         except KeyError:
             raise ValueError(f"Unknown compression type: {value}. Valid values are: {', '.join(cls.__members__.keys())}")
 
-def insert_yaml_as_extern(transformer, file, template_args=None):
+def _compress(data: bytes, compression_type: 'CompressionType') -> bytes:
+    """Compress data using the specified compression algorithm."""
+    if compression_type == CompressionType.ZLIB:
+        return zlib.compress(data)
+    elif compression_type == CompressionType.ZSTD:
+        cctx = zstandard.ZstdCompressor()
+        return cctx.compress(data)
+    elif compression_type == CompressionType.LZ4:
+        return lz4.frame.compress(data)
+    elif compression_type == CompressionType.BROTLI:
+        return brotli.compress(data)
+    return data
+
+
+def insert_yaml_as_extern(transformer, file, template_args=None, compression_type=None):
     """
     Include external YAML by transforming it to JSON and using zserio.
 
@@ -38,12 +52,27 @@ def insert_yaml_as_extern(transformer, file, template_args=None):
         transformer (YamlTransformer): The transformer instance.
         file (str): Path to the external YAML file.
         template_args (dict, optional): A dictionary of template arguments for placeholder replacement.
+        compression_type (Union[CompressionType, str, int, None]): Compression to apply
+            after serialization. Can be a CompressionType enum, string, or integer.
+            Defaults to None (no compression).
 
     Returns:
         dict: A dictionary containing the binary data and its bit size.
     """
     from .yaml_transformer import TransformationError
-    
+
+    # Resolve compression_type to enum
+    ct_enum = None
+    if compression_type is not None:
+        if isinstance(compression_type, str):
+            ct_enum = CompressionType.from_string(compression_type)
+        elif isinstance(compression_type, int):
+            ct_enum = CompressionType(compression_type)
+        elif isinstance(compression_type, CompressionType):
+            ct_enum = compression_type
+        else:
+            raise ValueError("compression_type must be a CompressionType enum, string, or integer value")
+
     abs_path = transformer.resolve_path(file)
     try:
         external_transformer = transformer.__class__(abs_path, template_args, initial_transformations=transformer.transformations)
@@ -56,7 +85,7 @@ def insert_yaml_as_extern(transformer, file, template_args=None):
             file_path=abs_path,
             original_error=e
         )
-    
+
     processed_data = external_transformer.data
     meta = external_transformer.metadata
 
@@ -84,11 +113,10 @@ def insert_yaml_as_extern(transformer, file, template_args=None):
             file_path=abs_path,
             original_error=e
         )
-    
+
     try:
         writer = zserio.BitStreamWriter()
         zserio_object.write(writer)
-        bits = zserio.BitBuffer(writer.byte_array, writer.bitposition)
     except Exception as e:
         raise TransformationError(
             f"Failed to serialize {schema_type}: {e}",
@@ -96,11 +124,18 @@ def insert_yaml_as_extern(transformer, file, template_args=None):
             original_error=e
         )
 
-    # Encode the binary data
-    encoded_bytes = list(bits.buffer)
-    data = {"buffer": encoded_bytes, "bitSize": bits.bitsize}
+    # Apply compression if requested
+    if ct_enum is not None and ct_enum != CompressionType.NO_COMPRESSION:
+        raw_bytes = bytes(writer.byte_array)
+        compressed = _compress(raw_bytes, ct_enum)
+        encoded_bytes = list(compressed)
+        bit_size = len(compressed) * 8
+    else:
+        bits = zserio.BitBuffer(writer.byte_array, writer.bitposition)
+        encoded_bytes = list(bits.buffer)
+        bit_size = bits.bitsize
 
-    return data
+    return {"buffer": encoded_bytes, "bitSize": bit_size}
 
 def insert_yaml(transformer, file, node_path='', template_args=None, cache_file=True):
     """
@@ -269,12 +304,16 @@ def extract_extern_as_yaml(transformer, buffer, bitSize, schema_module, schema_t
         yaml.dump(data_to_write, f, default_flow_style=False, sort_keys=False)
 
     # Return a reference to the extracted file
-    return {
+    ref = {
         '_f': 'insert_yaml_as_extern',
         '_a': {
             'file': file_name
         }
     }
+    # Propagate compression type so insert_yaml_as_extern re-compresses
+    if compression_type is not None and compression_type != CompressionType.NO_COMPRESSION:
+        ref['_a']['compression_type'] = compression_type.value
+    return ref
 
 def py_eval(transformer, expr):
     """

--- a/zs_yaml/built_in_transformations.py
+++ b/zs_yaml/built_in_transformations.py
@@ -44,6 +44,33 @@ def _compress(data: bytes, compression_type: 'CompressionType') -> bytes:
     return data
 
 
+def _decompress(data: bytes, compression_type: 'CompressionType') -> bytes:
+    """Decompress data using the specified compression algorithm."""
+    if compression_type == CompressionType.ZLIB:
+        return zlib.decompress(data)
+    elif compression_type == CompressionType.ZSTD:
+        dctx = zstandard.ZstdDecompressor()
+        return dctx.decompress(data)
+    elif compression_type == CompressionType.LZ4:
+        return lz4.frame.decompress(data)
+    elif compression_type == CompressionType.BROTLI:
+        return brotli.decompress(data)
+    return data
+
+
+def _resolve_compression_type(compression_type):
+    """Normalize a user-provided compression_type (enum/str/int/None) to a CompressionType or None."""
+    if compression_type is None:
+        return None
+    if isinstance(compression_type, CompressionType):
+        return compression_type
+    if isinstance(compression_type, str):
+        return CompressionType.from_string(compression_type)
+    if isinstance(compression_type, int):
+        return CompressionType(compression_type)
+    raise ValueError("compression_type must be a CompressionType enum, string, or integer value")
+
+
 def insert_yaml_as_extern(transformer, file, template_args=None, compression_type=None):
     """
     Include external YAML by transforming it to JSON and using zserio.
@@ -61,17 +88,7 @@ def insert_yaml_as_extern(transformer, file, template_args=None, compression_typ
     """
     from .yaml_transformer import TransformationError
 
-    # Resolve compression_type to enum
-    ct_enum = None
-    if compression_type is not None:
-        if isinstance(compression_type, str):
-            ct_enum = CompressionType.from_string(compression_type)
-        elif isinstance(compression_type, int):
-            ct_enum = CompressionType(compression_type)
-        elif isinstance(compression_type, CompressionType):
-            ct_enum = compression_type
-        else:
-            raise ValueError("compression_type must be a CompressionType enum, string, or integer value")
+    ct_enum = _resolve_compression_type(compression_type)
 
     abs_path = transformer.resolve_path(file)
     try:
@@ -221,7 +238,7 @@ def repeat_node(transformer, node, count):
     return [copy.deepcopy(node) for _ in range(count)]
 
 
-def extract_extern_as_yaml(transformer, buffer, bitSize, schema_module, schema_type, file_name, compression_type=0, remove_nulls=False):
+def extract_extern_as_yaml(transformer, buffer, bitSize, schema_module, schema_type, file_name, compression_type=None, remove_nulls=False):
     """
     Extract binary data and save as an external YAML file.
 
@@ -240,14 +257,7 @@ def extract_extern_as_yaml(transformer, buffer, bitSize, schema_module, schema_t
     Returns:
         dict: A reference to the extracted file.
     """
-    # Convert compression_type to enum if needed
-    if compression_type is not None:
-        if isinstance(compression_type, str):
-            compression_type = CompressionType.from_string(compression_type)
-        elif isinstance(compression_type, int):
-            compression_type = CompressionType(compression_type)
-        elif not isinstance(compression_type, CompressionType):
-            raise ValueError("compression_type must be a CompressionType enum, string, or integer value")
+    compression_type = _resolve_compression_type(compression_type)
 
     # Ensure the output directory exists
     output_dir = os.path.dirname(transformer.yaml_file_path)
@@ -259,15 +269,7 @@ def extract_extern_as_yaml(transformer, buffer, bitSize, schema_module, schema_t
     # Extract and decompress binary data if needed
     buffer = bytes(buffer)
     if compression_type is not None:
-        if compression_type == CompressionType.ZLIB:
-            buffer = zlib.decompress(buffer)
-        elif compression_type == CompressionType.ZSTD:
-            dctx = zstandard.ZstdDecompressor()
-            buffer = dctx.decompress(buffer)
-        elif compression_type == CompressionType.LZ4:
-            buffer = lz4.frame.decompress(buffer)
-        elif compression_type == CompressionType.BROTLI:
-            buffer = brotli.decompress(buffer)
+        buffer = _decompress(buffer, compression_type)
 
     # Import the module and get the type
     module = importlib.import_module(schema_module)


### PR DESCRIPTION
Release PR for zs-yaml 0.9.0.

## Changes so far

- Add compression support to `insert_yaml_as_extern` (fixes #19)
  - New optional `compression_type` parameter for compressing serialized data
  - `extract_extern_as_yaml` now propagates `compression_type` in returned references
  - Supports ZLIB, ZSTD, LZ4, and Brotli — symmetric with existing decompression