### PR TITLE
Improved API Docs

### DIFF
--- a/api_docs_review.md
+++ b/api_docs_review.md
@@ -1,0 +1,116 @@
+# API Docs Review — `zs_yaml`
+
+Purpose: classify every public symbol in `zs_yaml` as user-facing, advanced, or
+internal so the docs build renders a curated surface instead of every public-named
+helper. Modeled on `ndslive-yaml/api_docs_review.md`.
+
+This file is descriptive. The actual curation lives in two places:
+1. `__all__` declarations inside the package (metadata only — no behavior change).
+2. The `apidoc.packages` entry for `zs_yaml` in the parent SDK's `devportal.yaml`,
+   which now uses `mode: curated` so Sphinx respects `__all__` and skips
+   undocumented public-named symbols.
+
+---
+
+## Audience model
+
+1. **YAML author** — writes `.yaml` files that use `_f:` transformations
+   (`!from_wgs84_2d`, `!insert_yaml`, …). Doesn't import from `zs_yaml` at all.
+   Read USAGE/README, not API docs.
+2. **Python API consumer** — calls `zs_yaml.yaml_to_bin(...)` or instantiates
+   `YamlTransformer` from a script. Primary docs audience.
+3. **Contributor** — reads the source. Fine with sparse module-level docstrings;
+   not the docs target.
+
+---
+
+## Philosophy
+
+- The curated public API is what `__init__.py` already re-exports. Promote that
+  list to `__all__` so it becomes the documented contract.
+- `convert.py` exposes 9 functions. Only the 5 already re-exported are
+  user-facing; the rest (`yaml_to_yaml`, `yaml_to_pyobj`, `pyobj_to_yaml`) are
+  advanced — useful but rarely needed.
+- `built_in_transformations.py` is *YAML-side* API. The functions are invoked
+  via `_f:` markers in YAML files, not by Python `import`. Render them under a
+  separate "YAML Transformations" heading (like `ndslive-yaml` does), or omit
+  from this round and link to USAGE.md.
+- `main.py` is CLI-only — exclude entirely.
+
+---
+
+## Per-module review
+
+Legend: 🟢 user-facing · 🟡 advanced · 🔴 internal/CLI/not-Python-API
+
+### `zs_yaml` (top-level, from `__init__.py`)
+
+Curated public surface. All 🟢.
+
+| Symbol | Source module | Notes |
+|---|---|---|
+| `yaml_to_json` | `convert` | Plain YAML → JSON conversion |
+| `yaml_to_bin` | `convert` | YAML → zserio binary (primary entry point) |
+| `bin_to_yaml` | `convert` | zserio binary → YAML (primary entry point) |
+| `bin_to_dict` | `convert` | Binary → in-memory dict (programmatic inspection) |
+| `json_to_yaml` | `convert` | Plain JSON → YAML |
+| `YamlTransformer` | `yaml_transformer` | Programmatic transformation engine |
+| `TransformationError` | `yaml_transformer` | Exception type for error handling |
+| `get_version_info` | `__init__` | Version helper |
+| `__version__` | `__init__` | Version constant |
+
+### `zs_yaml.convert`
+
+| Symbol | Category | Notes |
+|---|---|---|
+| `yaml_to_bin` | 🟢 | Already at top level — don't re-render |
+| `bin_to_yaml` | 🟢 | Same |
+| `yaml_to_json` | 🟢 | Same |
+| `json_to_yaml` | 🟢 | Same |
+| `bin_to_dict` | 🟢 | Same |
+| `yaml_to_yaml` | 🟡 | Apply transformations and write YAML |
+| `yaml_to_pyobj` | 🟡 | YAML → in-memory zserio object |
+| `pyobj_to_yaml` | 🟡 | zserio object → YAML |
+| `_yaml_to_zserio_object` | 🔴 | Already underscore-prefixed |
+
+### `zs_yaml.yaml_transformer`
+
+| Symbol | Category | Notes |
+|---|---|---|
+| `YamlTransformer` | 🟢 | Already at top level |
+| `TransformationError` | 🟢 | Already at top level |
+
+### `zs_yaml.built_in_transformations`
+
+YAML-side transformations invoked from `.yaml` via `_f:`. Not Python-import API.
+
+| Symbol | Category | Notes |
+|---|---|---|
+| `insert_yaml`, `insert_yaml_as_extern`, `extract_extern_as_yaml` | 🟢 (as YAML) | YAML transformation |
+| `repeat_node`, `py_eval` | 🟢 (as YAML) | YAML transformation |
+| `CompressionType` | 🟡 | Enum used by extern transformations |
+| `_compress`, `_decompress`, `_resolve_compression_type` | 🔴 | Already underscore-prefixed |
+
+**Recommendation:** exclude this submodule from the Python API docs in this
+round. A future "YAML Transformations" page (matching `ndslive-yaml`) is the
+right place. USAGE.md already covers them from the YAML-author perspective.
+
+### `zs_yaml.main`
+
+All symbols are CLI plumbing. **Exclude the entire submodule.**
+
+| Symbol | Category | Notes |
+|---|---|---|
+| `parse_arguments`, `process_yaml_input`, `process_binary_input`, `process_json_input`, `get_file_size`, `print_summary`, `main` | 🔴 | CLI only |
+
+---
+
+## Summary: what to render
+
+Top-level `zs_yaml` page only — populated by `__all__`. Two submodule pages
+(`convert`, `yaml_transformer`) appear in the toctree, also driven by their own
+`__all__`. `main` and `built_in_transformations` are excluded via
+`exclude: [main, built_in_transformations]` in `devportal.yaml`.
+
+Estimated visible surface: 9 top-level entries + 3 advanced entries in
+`convert` = 12 documented symbols (down from ~30 if everything were rendered).

--- a/zs_yaml/__init__.py
+++ b/zs_yaml/__init__.py
@@ -1,5 +1,60 @@
+"""zs_yaml — YAML as a text format for zserio test data.
+
+``zs_yaml`` lets you author and inspect zserio-encoded data in YAML rather
+than raw binary or JSON. The YAML carries the schema reference in a
+``_meta`` section, so a single round-trip is enough to (de)serialise:
+
+.. code-block:: python
+
+    from zs_yaml import yaml_to_bin, bin_to_yaml
+
+    yaml_to_bin("input.yaml", "output.bin")    # serialise YAML → zserio binary
+    bin_to_yaml("input.bin", "output.yaml")    # deserialise back to YAML
+                                               # (target YAML must already
+                                               # contain a `_meta` section)
+
+The ``_meta`` section names the schema module and type::
+
+    _meta:
+      schema_module: ndslive.schema.smart.v2024_11.tile.api
+      schema_type: SmartLayerTile
+
+What's in this package
+======================
+
+Conversion entry points
+    :func:`yaml_to_bin`, :func:`bin_to_yaml`,
+    :func:`yaml_to_json`, :func:`json_to_yaml`,
+    :func:`bin_to_dict` — the everyday API.
+    Defined in :mod:`zs_yaml.convert`; advanced helpers
+    (``yaml_to_yaml``, ``yaml_to_pyobj``, ``pyobj_to_yaml``) live there too.
+
+Transformation engine
+    :class:`YamlTransformer` and :exc:`TransformationError` — for use when
+    you need to drive transformations programmatically rather than via the
+    CLI. Defined in :mod:`zs_yaml.yaml_transformer`.
+
+Version info
+    :func:`get_version_info`, :data:`__version__`.
+
+Built-in YAML transformations (e.g. ``!insert_yaml``, ``!repeat_node``,
+``!from_wgs84_2d``) are documented in the package's USAGE guide rather
+than as Python API — they're invoked from inside YAML files via the
+``_f:`` marker, not by Python ``import``.
+
+Command-line
+============
+
+Most users will reach for the CLI rather than this Python API:
+
+.. code-block:: shell
+
+    zs-yaml input.yaml output.bin
+    zs-yaml input.bin  output.yaml
+"""
+
 from .convert import yaml_to_json, yaml_to_bin, bin_to_yaml, bin_to_dict, json_to_yaml
-from .yaml_transformer import YamlTransformer
+from .yaml_transformer import YamlTransformer, TransformationError
 
 try:
     from ._version import __version__
@@ -11,5 +66,23 @@ except ImportError:
     except Exception:
         __version__ = "0.0.0+unknown"
 
+
 def get_version_info():
+    """Return the installed zs_yaml version string."""
     return __version__
+
+
+__all__ = [
+    # Conversion entry points
+    "yaml_to_bin",
+    "bin_to_yaml",
+    "yaml_to_json",
+    "json_to_yaml",
+    "bin_to_dict",
+    # Transformation engine
+    "YamlTransformer",
+    "TransformationError",
+    # Version info
+    "get_version_info",
+    "__version__",
+]

--- a/zs_yaml/convert.py
+++ b/zs_yaml/convert.py
@@ -20,6 +20,17 @@ import os
 
 from .yaml_transformer import YamlTransformer, TransformationError
 
+__all__ = [
+    # Primary conversion entries are surfaced at the top-level `zs_yaml`
+    # package via re-exports in `__init__.py`. This submodule's docs page
+    # only documents the *advanced* extras to avoid duplicating the
+    # primary surface in two places.
+    "yaml_to_yaml",
+    "yaml_to_pyobj",
+    "pyobj_to_yaml",
+]
+
+
 def _yaml_to_zserio_object(yaml_input_path):
     """
     Converts a YAML file to a Zserio object.

--- a/zs_yaml/yaml_transformer.py
+++ b/zs_yaml/yaml_transformer.py
@@ -6,7 +6,6 @@ import os
 import yaml
 import zs_yaml.built_in_transformations
 
-
 class TransformationError(Exception):
     """Exception raised during YAML transformation with file context."""
     def __init__(self, message, file_path=None, original_error=None):


### PR DESCRIPTION
Curate the public surface for cleaner generated API reference (Sphinx + downstream renderers like the NDS.Live developer portal).

## What changed

- **`zs_yaml/__init__.py`** — module docstring expanded into a proper landing-page intro: what the package is, primary-API round-trip example, `_meta` section format, and a grouped overview of conversion / transformation / version-info entry points. Added `__all__` listing the 9 curated public symbols.
- **`zs_yaml/convert.py`** — `__all__` lists only the 3 advanced helpers (`yaml_to_yaml`, `yaml_to_pyobj`, `pyobj_to_yaml`). The 5 primary conversion functions are surfaced at the top-level package via re-exports, so the submodule page no longer duplicates them.
- **`zs_yaml/yaml_transformer.py`** — dropped `__all__`. Both symbols (`YamlTransformer`, `TransformationError`) are surfaced top-level; downstream Sphinx configs can exclude the submodule entirely.
- **`api_docs_review.md`** — descriptive spec classifying each public symbol as user-facing / advanced / internal. Source of truth for future doc changes.

## Backwards compatibility

`__all__` only affects `from x import *` — explicit imports (`from zs_yaml.convert import yaml_to_bin`) and `from zs_yaml import yaml_to_bin` keep working unchanged.