### PR TITLE
Release 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-07
+
+### Fixed
+- `bin_to_dict` / `bin_to_yaml`: the per-`TypeInfo` descriptor cache used `id(type_info)` as its key while only holding a weak hold on the type. After garbage collection, CPython could reuse that memory address for an unrelated zserio class and the cache would return a stale descriptor, surfacing as spurious `'X' object has no attribute 'y'` errors in long-running processes (e.g. multi-test suites that load several schemas). The cache now keys on the `TypeInfo` object itself.
+
 ## [0.10.0] - 2026-05-07
 
 ### Changed

--- a/zs_yaml/convert.py
+++ b/zs_yaml/convert.py
@@ -97,11 +97,13 @@ _COMPOUND_CACHE = {}
 
 
 def _compound_descriptor(type_info):
-    tid = id(type_info)
-    desc = _COMPOUND_CACHE.get(tid)
+    # Key on the type_info object itself, not id(type_info): id() reuses memory
+    # addresses after GC, which would return a stale descriptor pointing at the
+    # fields of a previous, unrelated zserio class.
+    desc = _COMPOUND_CACHE.get(type_info)
     if desc is None:
         desc = _CompoundDescriptor(type_info)
-        _COMPOUND_CACHE[tid] = desc
+        _COMPOUND_CACHE[type_info] = desc
     return desc
 
 


### PR DESCRIPTION
0.10.1 fix release.

## Summary

- Fixes a stale-cache bug in `_compound_descriptor`: keying on `id(type_info)` while only storing the descriptor let CPython reuse a freed `TypeInfo`'s memory address for an unrelated zserio class, returning a stale descriptor and surfacing as spurious `'X' object has no attribute 'y'` errors during `bin_to_dict` / `bin_to_yaml` in long-running processes that load multiple schemas (e.g. multi-test suites).
- Cache is now keyed on the `TypeInfo` object itself.
- Cut `[0.10.1]` changelog entry.

## Test plan

- [x] Reproduced as 9 cross-test failures in `ndslive-yaml` against unfixed dev (and 2 against PyPI 0.10.0); all 154 ndslive-yaml tests pass against this fix.
- [x] zs-yaml example tests (run by CI inside their per-example dirs with generated APIs) — let CI validate.