### PR TITLE
Tighten 0.10.1 changelog entry: summary + issue reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.1] - 2026-05-07
+## [0.10.1] - 2026-05-08
 
 ### Fixed
-- `bin_to_dict` / `bin_to_yaml`: the per-`TypeInfo` descriptor cache used `id(type_info)` as its key while only holding a weak hold on the type. After garbage collection, CPython could reuse that memory address for an unrelated zserio class and the cache would return a stale descriptor, surfacing as spurious `'X' object has no attribute 'y'` errors in long-running processes (e.g. multi-test suites that load several schemas). The cache now keys on the `TypeInfo` object itself.
+- Stale `TypeInfo` descriptor cache in `bin_to_dict` / `bin_to_yaml` (#26).
 
 ## [0.10.0] - 2026-05-07
 


### PR DESCRIPTION
Pre-release polish for v0.10.1.

## Summary

- Replace the verbose 0.10.1 entry with a one-line summary that points at #26 for full context.
- Bump the date to today (2026-05-08).

Issue and release-draft notes use the same shape: short summary + issue link.