### PR TITLE
Expose data_to_zserio_object public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
             echo "Conversion tests failed"
             exit 1
           fi
+      - name: Test data_to_zserio_object public API
+        run: |
+          cd examples/team
+          python test_data_to_zserio_object.py
       - name: Generate schema API for extern_compression example
         run: |
           cd examples/extern_compression

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `data_to_zserio_object(data, imported_type, init_args=None)` public API: builds a Zserio object directly from an in-memory dict tree, with no JSON detour. Same fast path that `yaml_to_bin` / `yaml_to_pyobj` already use internally — exposed so downstream tools holding a transformed Python tree (e.g. SmartLayer wrappers with embedded extern buffers) can avoid the `json.dump` + `zserio.from_json_stream` roundtrip.
+
 ## [0.10.1] - 2026-05-07
 
 ### Fixed

--- a/examples/team/test_data_to_zserio_object.py
+++ b/examples/team/test_data_to_zserio_object.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Tests for the public ``data_to_zserio_object`` API.
+
+We build a Team object two ways from the same transformed dict — via the new
+public ``data_to_zserio_object`` and via the JSON detour
+(``json.dump`` + ``zserio.from_json_stream``) — and assert their serialized
+binary output is byte-identical.
+"""
+import io
+import os
+import sys
+import json
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+import zserio
+
+from zs_yaml import data_to_zserio_object
+from zs_yaml.yaml_transformer import YamlTransformer
+
+
+def _serialize(zs_obj) -> bytes:
+    writer = zserio.BitStreamWriter()
+    zs_obj.write(writer)
+    return bytes(writer.byte_array)
+
+
+def test_data_to_zserio_object_matches_json_detour():
+    print("Testing data_to_zserio_object byte-equality vs JSON detour...")
+
+    # Use the existing team1.yaml as the source
+    transformer = YamlTransformer("team1.yaml")
+    data = transformer.data
+    meta = transformer.metadata
+
+    import importlib
+    module = importlib.import_module(meta["schema_module"])
+    Team = getattr(module, meta["schema_type"])
+
+    # Path A: new public API
+    obj_direct = data_to_zserio_object(data, Team)
+    bytes_direct = _serialize(obj_direct)
+
+    # Path B: JSON detour (what ndslive-yaml currently does)
+    json_str = json.dumps(data)
+    obj_json = zserio.from_json_string(Team, json_str)
+    bytes_json = _serialize(obj_json)
+
+    assert bytes_direct == bytes_json, (
+        f"Mismatch: direct={len(bytes_direct)} bytes, json_detour={len(bytes_json)} bytes"
+    )
+    print(f"  ✓ identical {len(bytes_direct):,} bytes via both paths")
+    return True
+
+
+def test_init_args_passthrough():
+    """Verify that ``init_args=None`` and ``init_args=()`` are equivalent."""
+    print("\nTesting init_args=None vs init_args=()...")
+    transformer = YamlTransformer("team1.yaml")
+    import importlib
+    module = importlib.import_module(transformer.metadata["schema_module"])
+    Team = getattr(module, transformer.metadata["schema_type"])
+
+    obj_a = data_to_zserio_object(transformer.data, Team)
+    obj_b = data_to_zserio_object(transformer.data, Team, init_args=())
+    obj_c = data_to_zserio_object(transformer.data, Team, init_args=None)
+    assert _serialize(obj_a) == _serialize(obj_b) == _serialize(obj_c)
+    print("  ✓ all three forms produce identical output")
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        test_data_to_zserio_object_matches_json_detour()
+        test_init_args_passthrough()
+        print("\n✅ data_to_zserio_object tests passed!")
+        sys.exit(0)
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/zs_yaml/__init__.py
+++ b/zs_yaml/__init__.py
@@ -53,7 +53,14 @@ Most users will reach for the CLI rather than this Python API:
     zs-yaml input.bin  output.yaml
 """
 
-from .convert import yaml_to_json, yaml_to_bin, bin_to_yaml, bin_to_dict, json_to_yaml
+from .convert import (
+    yaml_to_json,
+    yaml_to_bin,
+    bin_to_yaml,
+    bin_to_dict,
+    json_to_yaml,
+    data_to_zserio_object,
+)
 from .yaml_transformer import YamlTransformer, TransformationError
 
 try:
@@ -79,6 +86,7 @@ __all__ = [
     "yaml_to_json",
     "json_to_yaml",
     "bin_to_dict",
+    "data_to_zserio_object",
     # Transformation engine
     "YamlTransformer",
     "TransformationError",

--- a/zs_yaml/convert.py
+++ b/zs_yaml/convert.py
@@ -29,6 +29,7 @@ __all__ = [
     "yaml_to_yaml",
     "yaml_to_pyobj",
     "pyobj_to_yaml",
+    "data_to_zserio_object",
 ]
 
 
@@ -267,6 +268,37 @@ def _construct_child(type_info, data, parent, type_args_lambdas, element_index):
 def _dict_to_zserio_object(data, ImportedType, init_args):
     desc = _compound_descriptor(ImportedType.type_info())
     return _build_compound(desc, data, init_args or ())
+
+
+def data_to_zserio_object(data, imported_type, init_args=None):
+    """
+    Build a Zserio object directly from an in-memory Python ``dict`` tree.
+
+    This is the same fast path used internally by :func:`yaml_to_bin` and
+    :func:`yaml_to_pyobj`: it walks the schema descriptor for ``imported_type``
+    and assigns fields from ``data`` field-by-field, with no JSON detour. For
+    payloads with large ``extern`` blobs (millions of bytes), this avoids the
+    text-based JSON roundtrip that ``zserio.from_json_stream`` would otherwise
+    perform.
+
+    The expected ``data`` shape is the same dict tree produced by zs-yaml's
+    transformer (or by :func:`bin_to_dict` in the reverse direction):
+
+    - extern fields use ``{"buffer": [int, ...], "bitSize": int}``
+    - bytes fields use ``{"buffer": [int, ...]}``
+    - enums and bitmasks accept either their string spelling or numeric value
+    - compound fields are nested dicts; arrays of compounds are lists of dicts
+
+    Args:
+        data: The transformed Python tree (without ``_meta``).
+        imported_type: The generated zserio class (e.g. ``team.api.Team``).
+        init_args: Optional iterable of zserio initialization arguments. ``None``
+            and ``()`` are equivalent.
+
+    Returns:
+        An instance of ``imported_type`` populated from ``data``.
+    """
+    return _dict_to_zserio_object(data, imported_type, init_args)
 
 
 # ---- reverse: zserio object -> dict ----------------------------------------


### PR DESCRIPTION
Promote the existing internal ``_dict_to_zserio_object`` to a public ``data_to_zserio_object`` so downstream tools holding a transformed Python tree can build a zserio object without going through ``json.dump`` + ``zserio.from_json_stream``.

Motivation: in ndslive-yaml, building a SmartLayerTile that wraps three datalayers via ``include_extern`` currently spends 84+ seconds on the JSON detour, because each embedded datalayer ends up as a list of millions of integer bytes that get serialized to JSON text and parsed back by zserio's character-by-character JSON tokenizer. zs-yaml's own ``yaml_to_bin`` already avoids this — exposing the underlying helper lets ndslive-yaml use the same fast path.

- new public function ``zs_yaml.data_to_zserio_object(data, imported_type, init_args=None)`` that wraps the internal ``_dict_to_zserio_object``
- re-exported from ``zs_yaml/__init__.py`` and added to ``convert.py``'s ``__all__``
- new ``examples/team/test_data_to_zserio_object.py`` asserts byte-equality with the JSON-detour path on ``team1.yaml``
- CI gains a step that runs the new test
- CHANGELOG entry under [Unreleased]

## Test plan
- [x] ``examples/team/test_data_to_zserio_object.py`` passes (byte-identical to JSON detour)
- [x] No regression in existing tests (convert.py change is additive)