### PR TITLE
release/0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-02
+
+### Added
+- `bin -> yaml` can now take the zserio type directly via `--type <module.TypeName>` (and optional `--init-args`), so the target YAML no longer has to be pre-created with a `_meta` block. Fully backward compatible: when `--type` is omitted, the existing read-target-`_meta` behavior (including any `transformation_module`) is unchanged. `bin_to_yaml(...)` gains matching optional `schema_module`/`schema_type`/`init_args` parameters. Fixes #30
+
 ## [0.10.1] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.0] - 2026-06-02
+## [0.11.0] - 2026-06-09
 
 ### Added
 - `bin -> yaml` can now take the zserio type directly via `--type <module.TypeName>` (and optional `--init-args`), so the target YAML no longer has to be pre-created with a `_meta` block. Fully backward compatible: when `--type` is omitted, the existing read-target-`_meta` behavior (including any `transformation_module`) is unchanged. `bin_to_yaml(...)` gains matching optional `schema_module`/`schema_type`/`init_args` parameters. Fixes #30

--- a/examples/team/test_all_conversions.py
+++ b/examples/team/test_all_conversions.py
@@ -217,6 +217,53 @@ def test_bin_to_yaml():
         raise
 
 
+def test_bin_to_yaml_with_type_arg():
+    """Test bin_to_yaml with the type passed directly, no pre-existing target.
+
+    Regression for ndsev/zs-yaml#30: schema_module/schema_type (CLI --type) allow
+    binary -> YAML without a pre-created target file containing _meta.
+    """
+    print("\nTesting bin_to_yaml with --type (no pre-existing target)...")
+
+    result = subprocess.run(['zs-yaml', 'team1.yaml', 'test_bin_to_yaml_type.bin'],
+                            capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception(f"Failed to create binary file: {result.stderr}")
+
+    out_path = 'test_bin_to_yaml_type_out.yaml'
+    cli_out = 'test_bin_to_yaml_type_cli.yaml'
+    for p in (out_path, cli_out):
+        if os.path.exists(p):
+            os.unlink(p)
+
+    try:
+        # API: pass the type directly; the target file does not exist yet.
+        bin_to_yaml('test_bin_to_yaml_type.bin', out_path,
+                    schema_module='team.api', schema_type='Team')
+        with open(out_path, 'r') as f:
+            output_data = yaml.safe_load(f)
+        assert output_data['_meta']['schema_module'] == 'team.api'
+        assert output_data['_meta']['schema_type'] == 'Team'
+        assert output_data['name'] == "Dream Team", "Team name doesn't match"
+        assert 'members' in output_data, "members field missing"
+
+        # CLI: end-to-end --type path.
+        r = subprocess.run(
+            ['zs-yaml', 'test_bin_to_yaml_type.bin', cli_out, '--type', 'team.api.Team'],
+            capture_output=True, text=True)
+        assert r.returncode == 0, f"CLI --type failed: {r.stderr}"
+        with open(cli_out, 'r') as f:
+            cli_data = yaml.safe_load(f)
+        assert cli_data['name'] == "Dream Team"
+
+        print("   ✓ bin -> yaml via --type successful")
+        return True
+    finally:
+        for p in ('test_bin_to_yaml_type.bin', out_path, cli_out):
+            if os.path.exists(p):
+                os.unlink(p)
+
+
 def test_yaml_to_yaml_with_template_args():
     """Test yaml_to_yaml with template argument substitution"""
     print("\nTesting yaml_to_yaml with template arguments...")
@@ -336,6 +383,7 @@ if __name__ == "__main__":
         json_path = test_yaml_to_json()
         test_json_to_yaml(json_path)
         test_bin_to_yaml()
+        test_bin_to_yaml_with_type_arg()
         test_yaml_to_yaml_with_template_args()
         test_descriptor_cache_keyed_on_object_not_id()
 

--- a/zs_yaml/convert.py
+++ b/zs_yaml/convert.py
@@ -540,34 +540,58 @@ def bin_to_dict(bin_input, schema_module, schema_type, init_args=None):
         )
 
 
-def bin_to_yaml(bin_input_path, yaml_output_path):
+def bin_to_yaml(bin_input_path, yaml_output_path, schema_module=None, schema_type=None, init_args=None):
     """
     Converts a binary file to a YAML file using Zserio deserialization.
+
+    The deserialization type can be supplied in two ways:
+
+    1. By passing ``schema_module`` and ``schema_type`` directly. In this case the
+       output YAML file does not need to exist beforehand; a minimal ``_meta``
+       block is synthesized from the provided type.
+    2. By leaving them as ``None`` (the default). Then the target YAML file must
+       already exist and contain a ``_meta`` block with ``schema_module`` and
+       ``schema_type`` (the original behavior, preserved for backward compatibility).
+       Any extra ``_meta`` keys (e.g. ``transformation_module``) are kept.
 
     Args:
         bin_input_path (str): Path to the input binary file.
         yaml_output_path (str): Path to the output YAML file.
+        schema_module (str, optional): Fully-qualified schema module name.
+        schema_type (str, optional): Schema type name.
+        init_args (list, optional): Initialization arguments for deserialization.
 
     Raises:
-        ValueError: If schema_module and schema_type are not specified in the _meta
-            section of the YAML file, or if the specified Zserio type is not found
-            in the module.
+        ValueError: If the type cannot be determined (neither passed directly nor
+            available in the target YAML file's ``_meta`` section).
     """
     try:
-        with open(yaml_output_path, 'r') as yaml_file:
-            meta = yaml.safe_load(yaml_file)
+        if schema_module and schema_type:
+            # Type provided directly: no pre-existing target file required.
+            meta_block = {'schema_module': schema_module, 'schema_type': schema_type}
+            if init_args:
+                meta_block['initialization_args'] = init_args
+        else:
+            # Backward-compatible: read the type from the existing target's _meta.
+            with open(yaml_output_path, 'r') as yaml_file:
+                meta = yaml.safe_load(yaml_file)
 
-        schema_module = meta.get('_meta', {}).get('schema_module')
-        schema_type = meta.get('_meta', {}).get('schema_type')
-        init_args = meta.get('_meta', {}).get('initialization_args', [])
+            meta_block = (meta or {}).get('_meta', {})
+            schema_module = meta_block.get('schema_module')
+            schema_type = meta_block.get('schema_type')
+            init_args = meta_block.get('initialization_args', [])
 
-        if not schema_module or not schema_type:
-            raise ValueError("Error: schema_module and schema_type must be specified in the _meta section of the YAML file")
+            if not schema_module or not schema_type:
+                raise ValueError(
+                    "Error: schema_module and schema_type must be specified in the _meta "
+                    "section of the target YAML file, or passed via schema_module/schema_type "
+                    "(CLI: --type)"
+                )
 
         data, metadata = bin_to_dict(bin_input_path, schema_module, schema_type, init_args)
 
         # Create a new dictionary to ensure _meta comes first
-        final_data = {'_meta': meta['_meta']}
+        final_data = {'_meta': meta_block}
         final_data.update(data)
 
         with open(yaml_output_path, 'w') as yaml_file:

--- a/zs_yaml/main.py
+++ b/zs_yaml/main.py
@@ -19,8 +19,9 @@ def parse_arguments():
         description=
         f'%(prog)s {get_version_info()}\n\n'
         'Converts between YAML, JSON, and binary formats. '
-        'To convert from binary to YAML, the target YAML file must already exist with metadata. '
-        'The metadata is required to identify the correct Python type for deserialization.\n\n'
+        'To convert from binary to YAML, identify the type either by passing '
+        '--type <module.TypeName>, or via a pre-existing target YAML file that '
+        'already contains the metadata.\n\n'
         'The minimal metadata content in the target YAML file should be:\n'
         ' _meta:\n'
         ' schema_module: <module_name>\n'
@@ -36,6 +37,17 @@ def parse_arguments():
     )
     parser.add_argument('input_path', type=str, help='Path to the input file (YAML, JSON, or binary)')
     parser.add_argument('output_path', type=str, nargs='?', help='Path to the output file (YAML, JSON, or binary)')
+    parser.add_argument(
+        '--type', dest='qualified_type', type=str, default=None,
+        help='Fully-qualified zserio type for binary -> YAML, e.g. '
+             'pkg.module.TypeName. Alternative to a pre-existing target file '
+             'with _meta; when given, the target need not exist beforehand.'
+    )
+    parser.add_argument(
+        '--init-args', dest='init_args', nargs='*', default=None,
+        help='Initialization arguments for the zserio type (binary -> YAML). '
+             'Integers (incl. 0x..) are parsed as ints, everything else as strings.'
+    )
     parser.add_argument('--version', action='version', version=f'%(prog)s {get_version_info()}')
 
     if len(sys.argv) < 2:
@@ -62,10 +74,33 @@ def process_yaml_input(input_path, output_path):
 
     return output_path
 
-def process_binary_input(input_path, output_path):
+def _split_qualified_type(qualified_type):
+    """Split 'pkg.module.TypeName' into (schema_module, schema_type)."""
+    if '.' not in qualified_type:
+        raise ValueError(
+            f"--type must be a fully-qualified type 'module.TypeName', got '{qualified_type}'"
+        )
+    schema_module, schema_type = qualified_type.rsplit('.', 1)
+    return schema_module, schema_type
+
+def _parse_init_args(raw_args):
+    """Parse CLI init-args: ints (incl. 0x..) as ints, otherwise as strings."""
+    parsed = []
+    for a in raw_args:
+        try:
+            parsed.append(int(a, 0))
+        except ValueError:
+            parsed.append(a)
+    return parsed
+
+def process_binary_input(input_path, output_path, qualified_type=None, init_args=None):
     if not output_path:
         raise ValueError("Output path must be specified for binary input")
-    bin_to_yaml(input_path, output_path)
+    schema_module = schema_type = None
+    if qualified_type:
+        schema_module, schema_type = _split_qualified_type(qualified_type)
+    parsed_init_args = _parse_init_args(init_args) if init_args else None
+    bin_to_yaml(input_path, output_path, schema_module, schema_type, parsed_init_args)
     return output_path
 
 def process_json_input(input_path, output_path):
@@ -102,7 +137,9 @@ def main():
         if input_extension == '.yaml':
             output_path = process_yaml_input(args.input_path, args.output_path)
         elif input_extension == '.bin' or input_extension == '':
-            output_path = process_binary_input(args.input_path, args.output_path)
+            output_path = process_binary_input(
+                args.input_path, args.output_path, args.qualified_type, args.init_args
+            )
         elif input_extension == '.json':
             output_path = process_json_input(args.input_path, args.output_path)
         else:


### PR DESCRIPTION
bin->yaml: add --type to supply the zserio type without a pre-existing target (#30)
Convert binary -> YAML by naming the type directly, instead of requiring a pre-created target YAML with a `_meta` block.

- new `--type <module.TypeName>` CLI option (+ optional `--init-args`)
- `bin_to_yaml()` gains optional `schema_module`/`schema_type`/`init_args` params; `bin_to_dict` already supported this
- **fully backward compatible** — without `--type`, the existing read-target-`_meta` behavior (incl. `transformation_module`) is unchanged
- regression test (API + CLI) + changelog

Closes #30